### PR TITLE
Add a :request_tag config option

### DIFF
--- a/lib/wash_out/dispatcher.rb
+++ b/lib/wash_out/dispatcher.rb
@@ -31,8 +31,10 @@ module WashOut
     end
 
     def _map_soap_parameters
-      self.params = _load_params action_spec[:in],
+      self.params = _load_params(
+        action_spec[:in],
         _strip_empty_nodes(action_spec[:in], xml_data)
+      )
     end
 
     def _map_soap_headers
@@ -232,12 +234,19 @@ module WashOut
     end
 
     private
+
     def soap_action?
       soap_action.present?
     end
 
     def action_spec
-      self.class.soap_actions[soap_action]
+      self.class.soap_actions.fetch(soap_action)
+    rescue KeyError
+      raise SOAPError.new(
+        "The request soap action does not match the controller action." +
+        "Given '#{soap_action}'," +
+        "Expected: '#{self.class.soap_actions.keys.first}'"
+      )
     end
 
     def request_input_tag

--- a/lib/wash_out/soap.rb
+++ b/lib/wash_out/soap.rb
@@ -13,11 +13,17 @@ module WashOut
       #
       # An optional option :to can be passed to allow for names of SOAP actions
       # which are not valid Ruby function names.
+      #
+      # There is an optional :request_tag option to specify an alternative
+      # request tag for the message.  If unspecified, the request tag will be
+      # set as the :as option, which is not very clearly named and probably
+      # should be deprecated.
+      #
       # There is also an optional :header_return option to specify the format of the
       # SOAP response's header tag (<env:Header></env:Header>). If unspecified, there will
       # be no header tag in the response.
       def soap_action(action, options={})
-        if options[:as].present?
+        if options[:as].present? && options[:request_tag].blank?
           options[:to] ||= action
           action = options[:as]
         end
@@ -30,16 +36,21 @@ module WashOut
             options[:to] ||= action.to_s
             action         = action.to_s.camelize
           end
+        end
 
+        if options[:request_tag].blank?
+          if options[:as].present?
+            options[:request_tag] = options[:as]
+          else
+            options[:request_tag] = action
+          end
         end
 
         default_response_tag = soap_config.camelize_wsdl ? 'Response' : '_response'
         default_response_tag = action+default_response_tag
 
-
         self.soap_actions[action] = options.merge(
           :in           => WashOut::Param.parse_def(soap_config, options[:args]),
-          :request_tag  => options[:as] || action,
           :out          => WashOut::Param.parse_def(soap_config, options[:return]),
           :header_out   => options[:header_return].present? ? WashOut::Param.parse_def(soap_config, options[:header_return]) : nil,
           :to           => options[:to] || action,

--- a/spec/dummy/config/initializers/secret_token.rb
+++ b/spec/dummy/config/initializers/secret_token.rb
@@ -4,5 +4,4 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-Dummy::Application.config.secret_token = 'b8d5d5687c012c2ef1a7a6e8006172402c48a3dcccca67c076eaad81c4712ad236ca2717c3706df7b286468c749d223f22acb0d96c27bdf33bbdbb9684ad46e5'
 Dummy::Application.config.secret_key_base = 'ed27a919186a27649accc93ad8c2750a022ef255780e8a15a439658e9f8c520ed70ea071e596b2d23ed41163cf36c21ff5afcd31d19439bb1e4c420f2a57bce6'

--- a/spec/lib/wash_out_spec.rb
+++ b/spec/lib/wash_out_spec.rb
@@ -529,6 +529,31 @@ describe WashOut do
 
           expect{savon(:rocknroll)}.not_to raise_error
         end
+
+        it "accepts a request with a :request_tag different from the action" do
+          mock_controller do
+            soap_action "checkAnswer",
+              args: :integer,
+              return: :boolean,
+              request_tag: "checkAnswerRequest",
+              to: :check_answer # This is required for this to work. Need to error if this is missing.
+
+            def check_answer
+              render soap: (params[:value] == 42)
+            end
+          end
+
+          true_response = savon(:check_answer, 42).
+            fetch(:check_answer_response).
+            fetch(:value)
+
+          false_response = savon(:check_answer, 13).
+            fetch(:check_answer_response).
+            fetch(:value)
+
+          expect(true_response).to be true
+          expect(false_response).to be false
+        end
       end
     end
 


### PR DESCRIPTION
Reason for Change
=================
* In the `wash_out` gem, when configuring a SOAP endpoint, the incoming message body is assumed to have a "request tag" which is similar to the SOAP action name. For example:

Here is a valid SOAP request for an action called `searchBySsn` *but* with a request tag of `searchBySsnRequest` as generated by the [`savon`][1] gem:

[1]: https://github.com/savonrb/savon

```XML
<?xml version="1.0" encoding="UTF-8"?>

<env:Envelope
  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xmlns:request_tag="This is the namespace for the Request Tag"
  xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">

  <env:Body>
    <request_tag:searchBySsnRequest>
      <data>
        <callerInfo>
          <service>AnyText</service>
          <username>AnyText</username>
        </callerInfo>

        <ssn>1231231234</ssn>
      </data>
    </request_tag:searchBySsnRequest>
  </env:Body>
</env:Envelope>
```

* The existing `:as` configuration is supposed to implement this, but it also overwrites the expected SOAP action, leading to error. It's also very confusingly named.

Changes
=======
* Add an optional `:request_tag` configuration option.
* Pull the option-merging action apart a little bit to facilitate later refactoring.

Minor
-----
* Add a more specific error when the SOAP action does not match with the controller's allowed actions.
* Use parentheses and expand complex method calls across multiple lines for clarity.
* Remove deprectated secret key. Message `DEPRECATION WARNING: `secrets.secret_token` is deprecated in favor of `secret_key_base` and will be removed in Rails 6.0.`